### PR TITLE
Added support for Philips HUE (model: LWB010)

### DIFF
--- a/lib/devices/philips.hue.dimmable_bulb.js
+++ b/lib/devices/philips.hue.dimmable_bulb.js
@@ -1,0 +1,48 @@
+const HomeKitDevice = require('../HomeKitDevice')
+
+class PhilipsDimmableBulb extends HomeKitDevice {
+
+    static get description() {
+        return {
+            model: [
+                'LWB010',
+                'Philips LWB010'
+            ],
+            manufacturer: 'Philips',
+            name: 'Philips HUE',
+        }
+    }
+
+    getAvailbleServices() {
+        return [{
+            name: 'Bulb',
+            type: 'Lightbulb',
+        }]
+    }
+
+    onDeviceReady() {
+        this.mountServiceCharacteristic({
+            endpoint: 11,
+            cluster: 'genOnOff',
+            service: 'Bulb',
+            characteristic: 'On',
+            reportMinInt: 1,
+            reportMaxInt: 300,
+            reportChange: 1,
+            parser: 'onOff',
+        })
+
+        this.mountServiceCharacteristic({
+            endpoint: 11,
+            cluster: 'genLevelCtrl',
+            service: 'Bulb',
+            characteristic: 'Brightness',
+            reportMinInt: 1,
+            reportMaxInt: 300,
+            reportChange: 1,
+            parser: 'dim',
+        })
+    }
+}
+
+module.exports = PhilipsDimmableBulb


### PR DESCRIPTION
Added a new device: Philips HUE bulb model: LWB010. Tested and it works fine with my HomeBridge configuration.